### PR TITLE
Fixed command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Looking for a more involved guide on how to install this bot? Use the [installat
 
 ### Command Usage (Without Docker)
 
-1. **make start-local** or **./run.sh start local**: Starts the bot locally on your machine without Docker Compose.
+1. **make start-local** or **./run.sh start-local**: Starts the bot locally on your machine without Docker Compose.
 
 Note: If you use a VPS and start the bot without Docker, make sure to use `pm2` to keep the bot online 24/7.
 


### PR DESCRIPTION
Hello there!, The command originally was "./run.sh start local", which ran the docker version, The correct command was "./run.sh start-local" (Directly taken from the provided script, which I later noticed is in the picture..).
Thanks!.